### PR TITLE
ReferenceError: query is not defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ module.exports = function(options, Source) {
             if (err) {
                 err.key = key;
                 client.emit('error', err);
-                return Source.prototype.search.call(source, query, id, callback);
+                return Source.prototype.feature.call(source, id, callback);
             }
 
             // Cache hit.


### PR DESCRIPTION
https://github.com/mapbox/tilelive-memcached/blob/master/index.js#L118 query there does not appear to be defined in that scope.
