### PR TITLE
Adding content-length check

### DIFF
--- a/index.js
+++ b/index.js
@@ -178,6 +178,8 @@ function decode(encoded) {
     data.headers = JSON.parse(encoded.substr(0, breaker+1));
     data.headers['x-memcached'] = 'hit';
     data.buffer = new Buffer(encoded.substr(breaker), 'base64');
+    if (data.headers['content-length'] && data.headers['content-length'] != data.buffer.length)
+        throw new Error('Content length does not match');
     return data;
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -85,11 +85,13 @@ Testsource.prototype.get = function(url, callback) {
     case 'http://test/0/0/0.png':
         return callback(null, tiles.a, {
             'content-type': 'image/png',
+            'content-length': 11541,
             'last-modified': now.toUTCString()
         });
     case 'http://test/1/0/0.png':
         return callback(null, tiles.b, {
             'content-type': 'image/png',
+            'content-length': 6199,
             'last-modified': now.toUTCString()
         });
     case 'http://test/0/0/0.grid.json':


### PR DESCRIPTION
It may be that node-memcached checks this, but I'm not seeing where that happens. It appears that it only uses the length which memcached returns to handle the special case of [zero length responses](https://github.com/3rd-Eden/node-memcached/blob/master/lib/memcached.js#L498). As we store the original content-length header we can use it to check the value we get back from memcached.
